### PR TITLE
Fixed parsing of values with special symbols

### DIFF
--- a/src/Syntax/Parsers.cs
+++ b/src/Syntax/Parsers.cs
@@ -37,7 +37,6 @@ namespace Namespace2Xml.Syntax
 
         public static Parser<IEnumerable<IValueToken>> GetValueParser()
         {
-            var qualifiedName = GetQualifiedNameParser();
             var textValueToken = Parse.CharExcept("*")
                 .Except(Parse.LineTerminator)
                 .Except(Parse.String("${"))
@@ -47,11 +46,7 @@ namespace Namespace2Xml.Syntax
                     (IValueToken)new TextValueToken(text))
                 .Named("text value");
 
-            var referenceValueToken = Parse.String("${")
-                .Then(_ => qualifiedName)
-                .Then(parsedName => Parse.Char('}')
-                    .Return((IValueToken)new ReferenceValueToken(parsedName)))
-                .Named("reference");
+            var referenceValueToken = GetReferenceValueToken();
 
             var substituteValueToken = Parse.Char('*')
                 .Return((IValueToken)new SubstituteValueToken())
@@ -60,8 +55,18 @@ namespace Namespace2Xml.Syntax
             return referenceValueToken
                 .Or(substituteValueToken)
                 .Or(textValueToken)
+                .Or(Parse.AnyChar.Except(Parse.LineTerminator).Many().Text().Select(x => (IValueToken)new TextValueToken(x)))
                 .Many()
                 .Named("value");
+        }
+
+        public static Parser<IValueToken> GetReferenceValueToken()
+        {
+            return Parse.String("${")
+                .Then(_ => GetQualifiedNameParser())
+                .Then(parsedName =>
+                    Parse.Char('}').Return((IValueToken)new ReferenceValueToken(parsedName)))
+                .Named("reference");
         }
 
         public static Parser<IEnumerable<IProfileEntry>> GetProfileParser(int fileNumber, string fileName)


### PR DESCRIPTION
Fixed parsing.

Expected:

There should be no errors when parsing values like:
```
...=${date:universalTime=true:format=yyyy-MM-dd\THH\:mm\:ss.fffK}
...=${uppercase:${level}}
...=[${threadname}: ${threadid}]
...=${longdate}|${level:uppercase=true}|${logger}|${message} ${exception:format=tostring}
```
These values shoud be parsed as `TextValueToken`