### PR TITLE
Fixed entry type string

### DIFF
--- a/src/Semantics/TreeBuilder.cs
+++ b/src/Semantics/TreeBuilder.cs
@@ -84,7 +84,8 @@ namespace Namespace2Xml.Semantics
             Enum.TryParse<EntryType>(p.Name.Parts.Last().ToString(), out var type) &&
                 type switch
                 {
-                    EntryType.root or EntryType.filename or EntryType.output or EntryType.delimiter or EntryType.xmloptions => true,
+                    EntryType.root or EntryType.filename or EntryType.output or EntryType.delimiter or EntryType.xmloptions
+                        or EntryType.type => true,
                     _ => false,
                 };
 


### PR DESCRIPTION
Entry type `Type=string` not working when name contains substitutions

Profile:
```
a.b.c=true
```

Scheme:
```
*.b.c.type=string
a.output=yaml
a.filename=c:\test\test.yml
```

Expected:
```
b:
  c: 'true'
```

Actual
```
b:
  c: true
```