### PR TITLE
Fixed key substitute when profile name has substituteToken

### DIFF
--- a/src/QualifiedNameMatchDictionary.cs
+++ b/src/QualifiedNameMatchDictionary.cs
@@ -4,6 +4,8 @@ using NullGuard;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using MoreLinq;
+using Namespace2Xml.Formatters;
 
 namespace Namespace2Xml
 {
@@ -69,7 +71,10 @@ namespace Namespace2Xml
             if (key == null)
                 throw new ArgumentNullException(nameof(key));
             if (key.Parts.Count == 0)
-                throw new ArgumentException("The key is empty", nameof(key));
+            {
+                value = default;
+                return false;
+            }
 
             if (strict.TryGetValue(key.ToString(), out value))
                 return true;
@@ -86,6 +91,20 @@ namespace Namespace2Xml
                     middlePattern.IsMatch(keyHead.Substring(prefix.Length, keyHead.Length - prefix.Length - suffix.Length)) &&
                     nested.TryMatch(keyTail, out value))
                     return true;
+
+            if (key.HasSubstitute() && strict.Keys.Any())
+            {
+                foreach (var kvp in strict)
+                {
+                    var strictName = kvp.Key.Split('.').ToQualifiedName();
+                    var match = strictName.GetFullMatch(key);
+                    if (match != null)
+                    {
+                        value = kvp.Value;
+                        return true;
+                    }
+                }
+            }
 
             return false;
         }

--- a/src/QualifiedNameMatchDictionary.cs
+++ b/src/QualifiedNameMatchDictionary.cs
@@ -11,7 +11,7 @@ namespace Namespace2Xml
 {
     public class QualifiedNameMatchDictionary<T> : IQualifiedNameMatchDictionary<T>
     {
-        private readonly Dictionary<string, T> strict = new();
+        private readonly Dictionary<QualifiedName, T> strict = new();
         private readonly Dictionary<string, QualifiedNameMatchDictionary<T>> nested = new();
         private readonly Dictionary<string, (string keyTextPrefix, string keyTextSuffix, NamePart middlePattern, QualifiedNameMatchDictionary<T> nested)> nonStrict = new();
 
@@ -35,7 +35,7 @@ namespace Namespace2Xml
             if (keyHead.IsTextOnly())
             {
                 if (key.IsTextOnly())
-                    strict.Add(key.ToString(), value);
+                    strict.Add(key, value);
                 else
                 {
                     var keyTail = new QualifiedName(key.Parts.Skip(1));
@@ -76,7 +76,7 @@ namespace Namespace2Xml
                 return false;
             }
 
-            if (strict.TryGetValue(key.ToString(), out value))
+            if (strict.TryGetValue(key, out value))
                 return true;
 
             var keyHead = key.Parts[0].ToString();
@@ -96,7 +96,7 @@ namespace Namespace2Xml
             {
                 foreach (var kvp in strict)
                 {
-                    var strictName = kvp.Key.Split('.').ToQualifiedName();
+                    var strictName = kvp.Key;
                     var match = strictName.GetFullMatch(key);
                     if (match != null)
                     {

--- a/src/Semantics/PayloadExtensions.cs
+++ b/src/Semantics/PayloadExtensions.cs
@@ -122,6 +122,12 @@ namespace Namespace2Xml.Semantics
         public static bool IsTextOnly(this QualifiedName qualifiedName) =>
             qualifiedName.Parts.All(part => part.IsTextOnly());
 
+        public static bool HasSubstitute(this NamePart namePart) =>
+            namePart.Tokens.Any(token => token is SubstituteNameToken);
+
+        public static bool HasSubstitute(this QualifiedName qualifiedName) =>
+            qualifiedName.Parts.Any(part => part.HasSubstitute());
+
         public static QualifiedName ApplyFullMatch(this QualifiedName name, IReadOnlyList<string> match)
         {
             using (var enumerator = match.GetEnumerator())
@@ -219,6 +225,12 @@ namespace Namespace2Xml.Semantics
                     matches.AddRange(m);
 
             return matches.AsReadOnly();
+        }
+
+        [return: NullGuard.AllowNull]
+        public static IReadOnlyList<string> GetFullMatch(this QualifiedName input, QualifiedName pattern)
+        {
+            return input.Parts.GetFullMatch(pattern.Parts);
         }
 
         [return: NullGuard.AllowNull]


### PR DESCRIPTION
Pofile:

```
*.b=*
a=true
```
Scheme:

```
a.b.substitute=key
a.output=yaml
a.filename=c:\test\test.yml
```
Expected:

```
true
b: '*'
```

Actual:
```
true
b: a
```
