### PR TITLE
Fix substitute scheme

### DIFF
--- a/src/Semantics/TreeBuilder.cs
+++ b/src/Semantics/TreeBuilder.cs
@@ -84,7 +84,8 @@ namespace Namespace2Xml.Semantics
             Enum.TryParse<EntryType>(p.Name.Parts.Last().ToString(), out var type) &&
                 type switch
                 {
-                    EntryType.root or EntryType.filename or EntryType.output or EntryType.delimiter or EntryType.xmloptions => true,
+                    EntryType.root or EntryType.filename or EntryType.output or EntryType.delimiter or EntryType.xmloptions
+                        or EntryType.type or EntryType.substitute => true,
                     _ => false,
                 };
 


### PR DESCRIPTION
Please review it after PR #7 
Scheme substitute=key not working if scheme name has substituteToken

Pofile:

```
*.b=*
a=true
```
Scheme:

```
*.b.substitute=key
a.output=yaml
a.filename=c:\test\test.yml
```
Expected:

```
true
b: '*'
```
Actual:

```
true
b: a
```