### PR TITLE
Fixed scheme tree build

### DIFF
--- a/src/CompositionRoot.cs
+++ b/src/CompositionRoot.cs
@@ -30,7 +30,7 @@ namespace Namespace2Xml
             var profiles = await profileReader.ReadFiles(arguments.Inputs, cancellationToken);
             var input = profiles.Concat(profileReader.ReadVariables(arguments.Variables));
             var schemes = await profileReader.ReadFiles(arguments.Schemes, cancellationToken);
-            var usedNames = input.OfType<Payload>()
+            var usedNames = treeBuilder.ApplyNameSubstitutesLoop(input).OfType<Payload>()
                         .Select(p => p.Name)
                         .Distinct()
                         .ToList();

--- a/src/QualifiedNameMatchDictionary.cs
+++ b/src/QualifiedNameMatchDictionary.cs
@@ -4,6 +4,8 @@ using NullGuard;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using MoreLinq;
+using Namespace2Xml.Formatters;
 
 namespace Namespace2Xml
 {
@@ -69,7 +71,10 @@ namespace Namespace2Xml
             if (key == null)
                 throw new ArgumentNullException(nameof(key));
             if (key.Parts.Count == 0)
-                throw new ArgumentException("The key is empty", nameof(key));
+            {
+                value = default;
+                return false;
+            }
 
             if (strict.TryGetValue(key.ToString(), out value))
                 return true;
@@ -86,6 +91,20 @@ namespace Namespace2Xml
                     middlePattern.IsMatch(keyHead.Substring(prefix.Length, keyHead.Length - prefix.Length - suffix.Length)) &&
                     nested.TryMatch(keyTail, out value))
                     return true;
+
+            if (key.HasSubstitute() && strict.Keys.Any())
+            {
+                foreach (var kvp in strict)
+                {
+                    var strictName = kvp.Key.Split('.').ToQualifiedName();
+                    var match = strictName.GetFullMatch(key);
+                    if (match != null)
+                    {
+                        value = kvp.Value;
+                        return true;
+                    }
+                }
+            }
 
             return false;
         }

--- a/src/QualifiedNameMatchDictionary.cs
+++ b/src/QualifiedNameMatchDictionary.cs
@@ -11,7 +11,7 @@ namespace Namespace2Xml
 {
     public class QualifiedNameMatchDictionary<T> : IQualifiedNameMatchDictionary<T>
     {
-        private readonly Dictionary<string, T> strict = new();
+        private readonly Dictionary<QualifiedName, T> strict = new();
         private readonly Dictionary<string, QualifiedNameMatchDictionary<T>> nested = new();
         private readonly Dictionary<string, (string keyTextPrefix, string keyTextSuffix, NamePart middlePattern, QualifiedNameMatchDictionary<T> nested)> nonStrict = new();
 
@@ -35,7 +35,7 @@ namespace Namespace2Xml
             if (keyHead.IsTextOnly())
             {
                 if (key.IsTextOnly())
-                    strict.Add(key.ToString(), value);
+                    strict.Add(key, value);
                 else
                 {
                     var keyTail = new QualifiedName(key.Parts.Skip(1));
@@ -76,7 +76,7 @@ namespace Namespace2Xml
                 return false;
             }
 
-            if (strict.TryGetValue(key.ToString(), out value))
+            if (strict.TryGetValue(key, out value))
                 return true;
 
             var keyHead = key.Parts[0].ToString();
@@ -96,7 +96,7 @@ namespace Namespace2Xml
             {
                 foreach (var kvp in strict)
                 {
-                    var strictName = kvp.Key.Split('.').ToQualifiedName();
+                    var strictName = kvp.Key;
                     var match = strictName.GetFullMatch(key);
                     if (match != null)
                     {

--- a/src/Semantics/ITreeBuilder.cs
+++ b/src/Semantics/ITreeBuilder.cs
@@ -13,5 +13,7 @@ namespace Namespace2Xml.Semantics
         IEnumerable<SchemeNode> BuildScheme(
             IEnumerable<IProfileEntry> enties,
             IEnumerable<QualifiedName> profileNames);
+
+        IEnumerable<IProfileEntry> ApplyNameSubstitutesLoop(IEnumerable<IProfileEntry> entries);
     }
 }

--- a/src/Semantics/PayloadExtensions.cs
+++ b/src/Semantics/PayloadExtensions.cs
@@ -122,6 +122,12 @@ namespace Namespace2Xml.Semantics
         public static bool IsTextOnly(this QualifiedName qualifiedName) =>
             qualifiedName.Parts.All(part => part.IsTextOnly());
 
+        public static bool HasSubstitute(this NamePart namePart) =>
+            namePart.Tokens.Any(token => token is SubstituteNameToken);
+
+        public static bool HasSubstitute(this QualifiedName qualifiedName) =>
+            qualifiedName.Parts.Any(part => part.HasSubstitute());
+
         public static QualifiedName ApplyFullMatch(this QualifiedName name, IReadOnlyList<string> match)
         {
             using (var enumerator = match.GetEnumerator())
@@ -219,6 +225,12 @@ namespace Namespace2Xml.Semantics
                     matches.AddRange(m);
 
             return matches.AsReadOnly();
+        }
+
+        [return: NullGuard.AllowNull]
+        public static IReadOnlyList<string> GetFullMatch(this QualifiedName input, QualifiedName pattern)
+        {
+            return input.Parts.GetFullMatch(pattern.Parts);
         }
 
         [return: NullGuard.AllowNull]

--- a/src/Semantics/TreeBuilder.cs
+++ b/src/Semantics/TreeBuilder.cs
@@ -84,7 +84,8 @@ namespace Namespace2Xml.Semantics
             Enum.TryParse<EntryType>(p.Name.Parts.Last().ToString(), out var type) &&
                 type switch
                 {
-                    EntryType.root or EntryType.filename or EntryType.output or EntryType.delimiter or EntryType.xmloptions => true,
+                    EntryType.root or EntryType.filename or EntryType.output or EntryType.delimiter or EntryType.xmloptions
+                        or EntryType.type or EntryType.substitute => true,
                     _ => false,
                 };
 

--- a/src/Semantics/TreeBuilder.cs
+++ b/src/Semantics/TreeBuilder.cs
@@ -505,7 +505,7 @@ namespace Namespace2Xml.Semantics
         {
             var entriesList = new ProfileEntryList(entries);
 
-            while (ApplySubstitutesStep(entriesList)) ;
+            while (ApplyNameSubstitutes(entriesList)) ;
 
             return entriesList.Where(entry =>
                 entry is not Payload p
@@ -543,12 +543,12 @@ namespace Namespace2Xml.Semantics
                 {
                     if (entries.InsertAfterIfNotExists(pattern, result.MatchedPayload))
                     {
-                        logger.LogDebug(
-                            "Substitute one-to-one by name: {name}, file: {file}, line: {line}, matches: {matches}",
-                            pattern.Name,
-                            pattern.SourceMark.FileName,
-                            pattern.SourceMark.LineNumber,
-                            result.MatchInfo);
+                        // logger.LogDebug(
+                        //     "Substitute one-to-one by name: {name}, file: {file}, line: {line}, matches: {matches}",
+                        //     pattern.Name,
+                        //     pattern.SourceMark.FileName,
+                        //     pattern.SourceMark.LineNumber,
+                        //     result.MatchInfo);
                         hasSubstitutes = true;
                     }
                 }

--- a/src/Semantics/TreeBuilder.cs
+++ b/src/Semantics/TreeBuilder.cs
@@ -501,6 +501,62 @@ namespace Namespace2Xml.Semantics
             return hasSubstitutes;
         }
 
+        public IEnumerable<IProfileEntry> ApplyNameSubstitutesLoop(IEnumerable<IProfileEntry> entries)
+        {
+            var entriesList = new ProfileEntryList(entries);
+
+            while (ApplySubstitutesStep(entriesList)) ;
+
+            return entriesList.Where(entry =>
+                entry is not Payload p
+                || p.GetNameSubstitutesCount() == 0);
+        }
+
+        private bool ApplyNameSubstitutes(ProfileEntryList entries)
+        {
+            bool hasSubstitutes = false;
+
+            var patterns = entries
+                .OfType<Payload>()
+                .Where(payload =>
+                    payload.GetNameSubstitutesCount() > 0
+                )
+                .ToList();
+
+            foreach (var pattern in patterns)
+            {
+                var matchesByName = entries.ToList().GetLeftMatches(pattern).ToList();
+
+                var substituteResults = matchesByName
+                    .Select(match => new
+                    {
+                        MatchedPayload = new Payload(
+                            pattern.Name.ApplyFullMatch(match.Match),
+                            pattern.Value,
+                            pattern.SourceMark),
+                        MatchInfo = match.Payload.GetSummary()
+                    })
+                    .Reverse()
+                    .ToList();
+
+                foreach (var result in substituteResults)
+                {
+                    if (entries.InsertAfterIfNotExists(pattern, result.MatchedPayload))
+                    {
+                        logger.LogDebug(
+                            "Substitute one-to-one by name: {name}, file: {file}, line: {line}, matches: {matches}",
+                            pattern.Name,
+                            pattern.SourceMark.FileName,
+                            pattern.SourceMark.LineNumber,
+                            result.MatchInfo);
+                        hasSubstitutes = true;
+                    }
+                }
+            }
+
+            return hasSubstitutes;
+        }
+
         private IEnumerable<IProfileEntry> ApplyReferences(IEnumerable<IProfileEntry> entries)
         {
             var valuesByName = entries


### PR DESCRIPTION
Please review it after PR https://github.com/stop-cran/namespace2xml/pull/8

Fixed scheme tree build - make profile name substitutes before scheme tree build.


Pofile:

```
*.b.c=*
a=true
```
Scheme:

```
*.b.*.substitute=key
a.output=yaml
a.filename=c:\test\test.yml
```
Expected:

```
true
b:
  c: '*'
```
Actual:

```
true
b:
  c: a
```