### PR TITLE
Fixed entity type Key for YamlFormatter and JsonFormatter

### DIFF
--- a/src/Semantics/TreeBuilder.cs
+++ b/src/Semantics/TreeBuilder.cs
@@ -84,7 +84,8 @@ namespace Namespace2Xml.Semantics
             Enum.TryParse<EntryType>(p.Name.Parts.Last().ToString(), out var type) &&
                 type switch
                 {
-                    EntryType.root or EntryType.filename or EntryType.output or EntryType.delimiter or EntryType.xmloptions => true,
+                    EntryType.root or EntryType.filename or EntryType.output or EntryType.delimiter
+                        or EntryType.xmloptions  or EntryType.key => true,
                     _ => false,
                 };
 


### PR DESCRIPTION
Fixed entity type Key for YamlFormatter and JsonFormatter

Pofile:
```
a.b.c.d=test
```
Scheme:
```
*.b.key=name
a.output=yaml
a.filename=c:\test\test.yml
```
Expected:
```
b:
- name: c
  d: test
```
Actual:
```
b:
  c:
    d: test
```