### PR TITLE
Updated logic for processing substitutes

### DIFF
--- a/src/Semantics/PayloadExtensions.cs
+++ b/src/Semantics/PayloadExtensions.cs
@@ -157,6 +157,8 @@ namespace Namespace2Xml.Semantics
         {
             using (var enumerator = match.GetEnumerator())
             {
+                var substituteCounter = 0;
+
                 var result = value.Select(token =>
                 {
                     switch (token)
@@ -164,18 +166,20 @@ namespace Namespace2Xml.Semantics
                         case TextValueToken _:
                             return token;
                         case SubstituteValueToken _:
-                            if (!enumerator.MoveNext())
-                                throw new ArgumentException($"Match count too small at {string.Join("", value)}: {string.Join(", ", match)}.");
+                            substituteCounter++;
+
+                            if (substituteCounter > match.Count)
+                                return new TextValueToken(enumerator.Current);
+
+                            enumerator.MoveNext();
+
                             return new TextValueToken(enumerator.Current);
-                        case ReferenceValueToken reference:
-                            return new ReferenceValueToken(reference.Name.ApplyMatch(enumerator, string.Join(", ", match)));
+                        case ReferenceValueToken _:
+                            return token;
                         default:
                             throw new NotSupportedException();
                     }
                 }).ToList();
-
-                if (enumerator.MoveNext())
-                    throw new ArgumentException($"Match count too big at {string.Join("", value)}: {string.Join(", ", match)}.");
 
                 return result;
             }

--- a/src/Semantics/TreeBuilder.cs
+++ b/src/Semantics/TreeBuilder.cs
@@ -272,230 +272,179 @@ namespace Namespace2Xml.Semantics
         {
             bool hasSubstitutes = false;
 
-            hasSubstitutes |= ApplySubstitutesStepNonStrict(entries);
+            hasSubstitutes |= ApplyNonStrictSubstitutesStep(entries);
             hasSubstitutes |= ApplyStrictSubstitutesStep(entries);
 
             return hasSubstitutes;
         }
 
-        private bool ApplySubstitutesStepNonStrict(ProfileEntryList entries)
+        private bool ApplyNonStrictSubstitutesStep(ProfileEntryList entries)
         {
             bool hasSubstitutes = false;
 
-            foreach (var tuple in (from pattern in entries.OfType<Payload>()
-                                   let nameSubstituteCount = pattern.GetNameSubstitutesCount()
-                                   let valueSubstituteCount = pattern.GetValueSubstitutesCount()
-                                   let refSubstituteCount = pattern.GetValueRefSubstitutesCount()
-                                   where valueSubstituteCount + refSubstituteCount > 0
-                                   select new
-                                   {
-                                       pattern,
-                                       nameSubstituteCount,
-                                       valueSubstituteCount,
-                                       refSubstituteCount
-                                   })
+            var patternsInfo = (from pattern in entries.OfType<Payload>()
+                    let nameSubstituteCount = pattern.GetNameSubstitutesCount()
+                    let valueSubstituteCount = pattern.GetValueSubstitutesCount()
+                    let refSubstituteCount = pattern.GetValueRefSubstitutesCount()
+                    where nameSubstituteCount > 0 && valueSubstituteCount + refSubstituteCount > 0
+                    select new
+                    {
+                        pattern,
+                        nameSubstituteCount,
+                        valueSubstituteCount,
+                        refSubstituteCount
+                    })
                 .Reverse()
-                .ToList())
+                .ToList();
+
+            foreach (var patternInfo in patternsInfo)
             {
-                int nameCnt = tuple.nameSubstituteCount;
-                int valCnt = tuple.valueSubstituteCount + tuple.refSubstituteCount;
+                var matchesByName = entries.ToList().GetLeftMatches(patternInfo.pattern).ToList();
 
-                if (nameCnt == valCnt)
+                if (!matchesByName.Any()) continue;
+
+                if (patternInfo.refSubstituteCount > 0)
                 {
-                    if (tuple.valueSubstituteCount == 0)
-                        foreach (var pair in tuple.pattern.Value
-                            .GetFullMatchesByReferences(entries.ToList())
-                            .Select(matches => new
+                    // Process substitutes in name, value and references
+
+                    var matchesByReferences = patternInfo.pattern.Value
+                        .GetFullMatchesByReferences(entries.ToList()).ToList();
+
+                    var correspondingMatchesToProcess =
+                        (from matchByName in matchesByName
+                            from matchByReferences in matchesByReferences
+                            let shouldProcess = matchByReferences
+                                .Select(matchByReference => matchByName.Match
+                                    .Zip(
+                                        matchByReference.Match,
+                                        (nameSubstitute, refSubstitute) =>
+                                            string.Equals(nameSubstitute, refSubstitute))
+                                    .All(x => x))
+                                .All(x => x)
+                            where shouldProcess
+                            select (matchByName, matchByReferences))
+                        .ToList();
+
+                    var substituteResults = correspondingMatchesToProcess
+                        .Select(matches =>
+                        {
+                            var qualifiedName = patternInfo.pattern.Name.ApplyFullMatch(matches.matchByName.Match);
+
+                            var value =
+                                patternInfo.valueSubstituteCount == 0
+                                    ? patternInfo.pattern.Value
+                                        .ApplyFullReferenceMatch(matches.matchByReferences
+                                            .Select(x => x.Payload.Name)
+                                            .ToList())
+                                    : patternInfo.pattern.Value
+                                        .ApplyFullReferenceMatch(matches.matchByReferences
+                                            .Select(x => x.Payload.Name)
+                                            .ToList()).ApplyFullMatch(matches.matchByName.Match);
+
+                            return new
                             {
                                 MatchedPayload = new Payload(
-                                    tuple.pattern.Name
-                                        .ApplyFullMatch(matches
-                                            .SelectMany(x => x.Match)
-                                            .ToList()),
-                                    tuple.pattern.Value
-                                        .ApplyFullReferenceMatch(matches
-                                            .Select(x => x.Payload.Name)
-                                            .ToList()),
-                                    tuple.pattern.SourceMark),
-                                MatchInfo = matches.GetMatchSummary()
-                            })
-                            .Reverse())
-                            if (entries.InsertAfterIfNotExists(tuple.pattern, pair.MatchedPayload))
-                            {
-                                logger.LogDebug("Substitute one-to-one by references, name: {name}, file: {file}, line: {line}, matches: {matches}",
-                                    tuple.pattern.Name,
-                                    tuple.pattern.SourceMark.FileName,
-                                    tuple.pattern.SourceMark.LineNumber,
-                                    pair.MatchInfo);
-                                hasSubstitutes = true;
-                            }
+                                    qualifiedName,
+                                    value,
+                                    patternInfo.pattern.SourceMark),
+                                MatchInfo = matches.matchByReferences.GetMatchSummary()
+                            };
+                        })
+                        .Reverse()
+                        .ToList();
 
-                    foreach (var pair in entries.ToList().GetLeftMatches(tuple.pattern)
+                    foreach (var result in substituteResults)
+                    {
+                        if (entries.InsertAfterIfNotExists(patternInfo.pattern, result.MatchedPayload))
+                        {
+                            logger.LogDebug(
+                                "Substitute by references, reference name: {name}, file: {file}, line: {line}, matches: {matches}",
+                                patternInfo.pattern.ValueToString(),
+                                patternInfo.pattern.SourceMark.FileName,
+                                patternInfo.pattern.SourceMark.LineNumber,
+                                result.MatchInfo);
+                            hasSubstitutes = true;
+                        }
+                    }
+                }
+                else if (patternInfo.valueSubstituteCount > 0)
+                {
+                    // Process substitutions in name and value
+
+                    var substituteResults = matchesByName
                         .Select(p => new
                         {
                             MatchedPayload = new Payload(
-                                tuple.pattern.Name.ApplyFullMatch(p.Match),
-                                tuple.pattern.Value.ApplyFullMatch(p.Match),
-                                tuple.pattern.SourceMark,
+                                patternInfo.pattern.Name.ApplyFullMatch(p.Match),
+                                patternInfo.pattern.Value.ApplyFullMatch(p.Match),
+                                patternInfo.pattern.SourceMark,
                                 true),
                             MatchInfo = p.Payload.GetSummary()
                         })
-                        .Reverse())
-                        if (entries.InsertAfterIfNotExists(tuple.pattern, pair.MatchedPayload))
-                        {
-                            logger.LogDebug("Substitute one-to-one by name: {name}, file: {file}, line: {line}, matches: {matches}",
-                                tuple.pattern.Name,
-                                tuple.pattern.SourceMark.FileName,
-                                tuple.pattern.SourceMark.LineNumber,
-                                pair.MatchInfo);
-                            hasSubstitutes = true;
-                        }
-                }
-                else if (nameCnt > valCnt && nameCnt % valCnt == 0)
-                {
-                    if (tuple.valueSubstituteCount == 0)
-                        foreach (var pair in tuple.pattern.Value
-                            .GetFullMatchesByReferences(entries.ToList())
-                            .Select(matches => new
-                            {
-                                MatchedPayload = new Payload(
-                                    tuple.pattern.Name.ApplyFullMatch(
-                                        Enumerable.Repeat(
-                                            matches.SelectMany(x => x.Match),
-                                            nameCnt / valCnt)
-                                        .SelectMany(x => x)
-                                        .ToList()),
-                                    tuple.pattern.Value
-                                        .ApplyFullReferenceMatch(matches
-                                            .Select(x => x.Payload.Name)
-                                            .ToList()),
-                                    tuple.pattern.SourceMark),
-                                MatchInfo = matches.GetMatchSummary()
-                            })
-                            .Reverse())
-                            if (entries.InsertAfterIfNotExists(tuple.pattern, pair.MatchedPayload))
-                            {
-                                logger.LogDebug("Substitute many-to-one by references, name: {name}, file: {file}, line: {line}, matches: {matches}",
-                                    tuple.pattern.Name,
-                                    tuple.pattern.SourceMark.FileName,
-                                    tuple.pattern.SourceMark.LineNumber,
-                                    pair.MatchInfo);
-                                hasSubstitutes = true;
-                            }
+                        .Reverse()
+                        .ToList();
 
-                    foreach (var pair in (from p in entries.ToList().GetLeftMatches(tuple.pattern)
-                                          where p.Match
-                                             .Batch(valCnt)
-                                             .SequenceDistinct()
-                                             .Count() == 1
-                                          select new
-                                          {
-                                              MatchedPayload = new Payload(
-                                                  tuple.pattern.Name.ApplyFullMatch(p.Match),
-                                                  tuple.pattern.Value.ApplyFullMatch(p.Match.Take(valCnt).ToList()),
-                                                  tuple.pattern.SourceMark,
-                                                  true),
-                                              MatchInfo = p.Payload.GetSummary()
-                                          }).Reverse())
-                        if (entries.InsertAfterIfNotExists(tuple.pattern, pair.MatchedPayload))
+                    foreach (var result in substituteResults)
+                    {
+                        if (entries.InsertAfterIfNotExists(patternInfo.pattern, result.MatchedPayload))
                         {
-                            logger.LogDebug("Substitute many-to-one by name, name: {name}, file: {file}, line: {line}, matches: {matches}",
-                                tuple.pattern.Name,
-                                tuple.pattern.SourceMark.FileName,
-                                tuple.pattern.SourceMark.LineNumber,
-                                pair.MatchInfo);
+                            logger.LogDebug(
+                                "Substitute by name: {name}, file: {file}, line: {line}, matches: {matches}",
+                                patternInfo.pattern.Name,
+                                patternInfo.pattern.SourceMark.FileName,
+                                patternInfo.pattern.SourceMark.LineNumber,
+                                result.MatchInfo);
                             hasSubstitutes = true;
                         }
+                    }
                 }
-                else if (nameCnt > 0 && nameCnt < valCnt && valCnt % nameCnt == 0)
-                {
-                    if (tuple.valueSubstituteCount == 0)
-                        foreach (var pair in (from matches in tuple.pattern.Value
-                                                .GetFullMatchesByReferences(entries.ToList())
-                                              where matches
-                                                  .Select(match => match.Match)
-                                                  .SequenceDistinct()
-                                                  .Count() == 1
-                                              select new
-                                              {
-                                                  MatchedPayload = new Payload(
-                                                      tuple.pattern.Name
-                                                          .ApplyFullMatch(matches.First().Match),
-                                                      tuple.pattern.Value
-                                                          .ApplyFullReferenceMatch(matches
-                                                              .Select(x => x.Payload.Name)
-                                                              .ToList()),
-                                                   tuple.pattern.SourceMark),
-                                                  MatchInfo = matches.GetMatchSummary()
-                                              }).Reverse())
-                            if (entries.InsertAfterIfNotExists(tuple.pattern, pair.MatchedPayload))
-                            {
-                                logger.LogDebug("Substitute one-to-many by references, name: {name}, file: {file}, line: {line}, matches: {matches}",
-                                    tuple.pattern.Name,
-                                    tuple.pattern.SourceMark.FileName,
-                                    tuple.pattern.SourceMark.LineNumber,
-                                    pair.MatchInfo);
-                                hasSubstitutes = true;
-                            }
-
-                    foreach (var pair in entries.ToList().GetLeftMatches(tuple.pattern)
-                        .Select(p => new
-                        {
-                            MatchedPayload = new Payload(
-                                tuple.pattern.Name.ApplyFullMatch(p.Match),
-                                tuple.pattern.Value.ApplyFullMatch(
-                                    Enumerable.Repeat(p.Match, valCnt / nameCnt)
-                                        .SelectMany(matches => matches)
-                                        .ToList()),
-                                tuple.pattern.SourceMark,
-                                true),
-                            MatchInfo = p.Payload.GetSummary()
-                        })
-                        .Reverse())
-                        if (entries.InsertAfterIfNotExists(tuple.pattern, pair.MatchedPayload))
-                        {
-                            logger.LogDebug("Substitute one-to-many by name, name: {name}, file: {file}, line: {line}, matches: {matches}",
-                                tuple.pattern.Name,
-                                tuple.pattern.SourceMark.FileName,
-                                tuple.pattern.SourceMark.LineNumber,
-                                pair.MatchInfo);
-                            hasSubstitutes = true;
-                        }
-                }
-                else if (nameCnt == 0 && tuple.refSubstituteCount == 0)
-                {
-                    // Flatten after applying other substitutes.
-                }
-                else
-                    entries[entries.IndexOf(tuple.pattern)] =
-                        new ProfileError(
-                            tuple.pattern.Name,
-                            $"Not supported substitute: {tuple.pattern} [{tuple.pattern.SourceMark.FileName}, line {tuple.pattern.SourceMark.LineNumber}].",
-                            tuple.pattern.SourceMark);
             }
 
             return hasSubstitutes;
         }
 
-        private static bool ApplyStrictSubstitutesStep(ProfileEntryList entries)
+        private bool ApplyStrictSubstitutesStep(ProfileEntryList entries)
         {
             bool hasSubstitutes = false;
 
-            foreach (var pattern in entries
+            var patterns = entries
                 .OfType<Payload>()
                 .Where(payload =>
                     payload.GetNameSubstitutesCount() > 0 &&
                     payload.GetValueSubstitutesCount() == 0 &&
                     payload.GetValueRefSubstitutesCount() == 0)
-                .ToList())
-                foreach (var match in (from payload in entries.OfType<Payload>()
-                                       let match = payload.GetLeftMatch(pattern)
-                                       where match != null
-                                       select new Payload(
-                                           pattern.Name.ApplyFullMatch(match),
-                                           pattern.Value,
-                                           pattern.SourceMark)).Reverse())
-                    hasSubstitutes |= entries.InsertAfterIfNotExists(pattern, match);
+                .ToList();
+
+            foreach (var pattern in patterns)
+            {
+                var matchesByName = entries.ToList().GetLeftMatches(pattern).ToList();
+
+                var substituteResults = matchesByName
+                    .Select(match => new
+                    {
+                        MatchedPayload = new Payload(
+                            pattern.Name.ApplyFullMatch(match.Match),
+                            pattern.Value,
+                            pattern.SourceMark),
+                        MatchInfo = match.Payload.GetSummary()
+                    })
+                    .Reverse()
+                    .ToList();
+
+                foreach (var result in substituteResults)
+                {
+                    if (entries.InsertAfterIfNotExists(pattern, result.MatchedPayload))
+                    {
+                        logger.LogDebug(
+                            "Substitute one-to-one by name: {name}, file: {file}, line: {line}, matches: {matches}",
+                            pattern.Name,
+                            pattern.SourceMark.FileName,
+                            pattern.SourceMark.LineNumber,
+                            result.MatchInfo);
+                        hasSubstitutes = true;
+                    }
+                }
+            }
 
             return hasSubstitutes;
         }

--- a/tests/TreeBuilderTests.cs
+++ b/tests/TreeBuilderTests.cs
@@ -131,7 +131,7 @@ a=1
         [Test]
         public void ShouldApplyReferenceSubstitutes()
         {
-            var tree = builder.Build(parser.Parse("a.x.y=1\na.*.*=1,*,${c.*}\nc.y=3"),
+            var tree = builder.Build(parser.Parse("a.x.y=1\na.*.*=1,*,${c.*}\nc.x=3"),
                 new QualifiedNameMatchDictionary<Scheme.SubstituteType>()).ToList();
 
             tree.Count.ShouldBe(2);
@@ -161,7 +161,7 @@ a=1
         [TestCase("a.x-x=1", "a.*-*=2", "x-x", "2")]
         [TestCase("a.x-x=1", "a.*-*=*", "x-x", "x")]
         [TestCase("a.x-x=1\nb.x=2", "a.*-*=${b.*}+1", "x-x", "2+1")]
-        [TestCase("b.x=2", "a.*-*=${b.*}+1", "x-x", "2+1")]
+        [TestCase("a.x-y=1\nb.x=2\nc.x=3\nc.y=4", "a.*-*=${b.*}+${c.*}", "x-y", "2+3")]
         public void ShouldApplySubstitute(string baseLine, string substitute, string expectedName, string expectedValue)
         {
             var tree = builder.Build(parser.Parse(baseLine).Concat(parser.Parse(substitute)),
@@ -190,7 +190,6 @@ a=1
         [Test]
         [TestCase("a.x=${a.x}", "Cyclic reference: a.x [file: testfile, line: 1] > a.x [file: testfile, line: 1].")]
         [TestCase("a.x=${b.x}", "Reference b.x was not found at a.x [file: testfile, line: 1].")]
-        [TestCase("a.**=***", "Not supported substitute: a.**=*** [testfile, line 1].")]
         public void ShouldConvertErrors(string profile, string expectedError) =>
             builder.Build(parser.Parse(profile),
                 new QualifiedNameMatchDictionary<Scheme.SubstituteType>())


### PR DESCRIPTION
Updated logic for processing substitutes.

### Original issue:
Pofile:
```
*.c.0.c1=1
*.c.1.c2=2
*.c.*.c3=${*.ref1}
a=true
a.ref1=3
```
Scheme:
```
*.c.output=yaml
*.c.filename=c:\test\test.yml
```
Expected:
```
- c1: 1
  c3: 3
- c2: 2
  c3: 3
```
Actual:
```
'0':
  c1: 1
'1':
  c2: 2
a:
  c3: 3
```

### Other changes:

1. Substitutions for names inside ReferenceValueToken are processed separately for each reference and separately from SubstiturteValueTokens

Profile:
```
a.x-y=1
b.x=2
c.x=3
c.y=4
a.*-*=${b.*}+${c.*}
```
Previous version substitution result: `a.x-y=${b.x}+${c.y} `->` x-y=2+4`
Current version substitution result: `a.x-y=${b.x}+${c.x} `->` x-y=2+3`

2. Different count of substitutes in name and value:

`a.b.c.d1=true`
Current version:
`*.b.*.d2=*` -> `a.b.c.d2=a`
`*.b.*.d2=*****` -> `a.b.c.d2=acccc`