### PR TITLE
Ignore namespace by adding exclamation mark

### DIFF
--- a/src/CompositionRoot.cs
+++ b/src/CompositionRoot.cs
@@ -30,8 +30,10 @@ namespace Namespace2Xml
         public async Task Write(Arguments arguments, CancellationToken cancellationToken)
         {
             var profiles = await profileReader.ReadFiles(arguments.Inputs, cancellationToken);
-            var input = profiles.Concat(profileReader.ReadVariables(arguments.Variables));
-            var schemes = await profileReader.ReadFiles(arguments.Schemes, cancellationToken);
+            var input = profiles.Concat(profileReader.ReadVariables(arguments.Variables)).ToList().AsReadOnly();
+            var schemes = (await profileReader.ReadFiles(arguments.Schemes, cancellationToken))
+                .WithIgnores(input);
+
             var usedNames = treeBuilder.ApplyNameSubstitutesLoop(input).OfType<Payload>()
                         .Select(p => p.Name)
                         .Distinct()

--- a/src/Formatters/Extensions.cs
+++ b/src/Formatters/Extensions.cs
@@ -70,10 +70,16 @@ namespace Namespace2Xml.Formatters
             var newPrefix = prefix.Concat(new[] { tree.NameString });
 
             if (tree is ProfileTreeNode node)
-                yield return new ProfileTreeNode(
-                    node.Name,
-                    node.Children
-                        .SelectMany(child => child.Ignore(ignore, newPrefix)));
+            {
+                var children = node.Children
+                    .SelectMany(child => child.Ignore(ignore, newPrefix)).ToList();
+                if (children.Any())
+                {
+                    yield return new ProfileTreeNode(
+                        node.Name,
+                        children);
+                }
+            }
             else if (!ignore.IsMatch(newPrefix.ToQualifiedName()))
                 yield return tree;
         }

--- a/src/Semantics/PayloadExtensions.cs
+++ b/src/Semantics/PayloadExtensions.cs
@@ -259,5 +259,17 @@ namespace Namespace2Xml.Semantics
                 .GetFullMatch(pattern.Parts.Take(leftPartsCount).ToList())
                 : null;
         }
+
+        public static IReadOnlyList<IProfileEntry> WithIgnores(this IReadOnlyList<IProfileEntry> schemeEntries,
+            IReadOnlyList<IProfileEntry> profileEntries)
+        {
+            return schemeEntries
+                .Concat(profileEntries.OfType<PayloadIgnore>()
+                    .Select(x => new Payload(
+                        new QualifiedName(x.Name.Parts.Append(new NamePart(new[] { new TextNameToken("type") }))),
+                        new[] { new TextValueToken("ignore") },
+                        x.SourceMark)))
+                .ToList().AsReadOnly();
+        }
     }
 }

--- a/src/Semantics/TreeBuilder.cs
+++ b/src/Semantics/TreeBuilder.cs
@@ -217,6 +217,7 @@ namespace Namespace2Xml.Semantics
 
                     case ProfileError _:
                     case Comment _:
+                    case PayloadIgnore _:
                         yield return entry;
                         break;
 
@@ -555,6 +556,7 @@ namespace Namespace2Xml.Semantics
 
                     case Comment _:
                     case ProfileError _:
+                    case PayloadIgnore _:
                         return new[] { entry };
 
                     default:
@@ -618,6 +620,9 @@ namespace Namespace2Xml.Semantics
 
                     case Comment comment:
                         leadingComments.Add(comment);
+                        break;
+
+                    case PayloadIgnore _:
                         break;
 
                     default:

--- a/src/Syntax/Parsers.cs
+++ b/src/Syntax/Parsers.cs
@@ -99,7 +99,16 @@ namespace Namespace2Xml.Syntax
                         span.Value.parsedValue,
                         new SourceMark(fileNumber, fileName, span.Start.Line)));
 
+            var payloadIgnore = Parse.Char('!').Token()
+                .Then(_ => GetQualifiedNameParser())
+                .Span()
+                .Select(span =>
+                    (IProfileEntry)new PayloadIgnore(
+                        span.Value,
+                        new SourceMark(fileNumber, fileName, span.Start.Line)));
+
             return comment
+                .Or(payloadIgnore)
                 .Or(payloadSpan)
                 .DelimitedBy(Parse.LineTerminator.AtLeastOnce())
                 .Contained(

--- a/src/Syntax/Parsers.cs
+++ b/src/Syntax/Parsers.cs
@@ -99,16 +99,27 @@ namespace Namespace2Xml.Syntax
                         span.Value.parsedValue,
                         new SourceMark(fileNumber, fileName, span.Start.Line)));
 
-            var payloadIgnore = Parse.Char('!').Token()
+            var payloadNameIgnore = Parse.Char('!').Token()
                 .Then(_ => GetQualifiedNameParser())
                 .Span()
                 .Select(span =>
                     (IProfileEntry)new PayloadIgnore(
                         span.Value,
-                        new SourceMark(fileNumber, fileName, span.Start.Line)));
+                        new SourceMark(fileNumber, fileName, span.Start.Line)))
+                .Named("payloadNameIgnore");
+
+            var payloadIgnore = Parse.Char('!').Token()
+                .Then(_ => payload)
+                .Span()
+                .Select(span =>
+                    (IProfileEntry)new PayloadIgnore(
+                        span.Value.parsedName,
+                        new SourceMark(fileNumber, fileName, span.Start.Line)))
+                .Named("payload");
 
             return comment
                 .Or(payloadIgnore)
+                .Or(payloadNameIgnore)
                 .Or(payloadSpan)
                 .DelimitedBy(Parse.LineTerminator.AtLeastOnce())
                 .Contained(

--- a/src/Syntax/PayloadIgnore.cs
+++ b/src/Syntax/PayloadIgnore.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace Namespace2Xml.Syntax;
+
+public class PayloadIgnore : NamedProfileEntry
+{
+    public PayloadIgnore(QualifiedName name, SourceMark sourceMark) : base(name, sourceMark)
+    {
+    }
+}


### PR DESCRIPTION
- Ignore namespace by adding exclamation mark
- Fixed bug when namespace to ignore contains substitutes

Profile:
```
a.b.c=1
a.b.d=2
a.b.e=3
a.x.y=4
a.x.z=5
!a.x.*
```

Expected:
```
b:
  c: 1
  d: 2
  e: 3
```

How to ignore namespace:
`!a.x.*` or `!a.x.*=test`