### PR TITLE
Added multiline value type

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,102 +77,268 @@ The value overriding is performed from the beginnging to the end, giving priorit
  
 ## Support for value references and wildcard substitutes
 
-Reference one value from another:
+### Reference one value from another:
+Example:
 
-Input:
+*Input*
 ```
 a.x=1,${b.y},3
 b.y=2
 ```
-Evaluates to:
+*Schema*
 ```
-a.x=1,2,3
-b.y=2
+a.output=namespace
 ```
-
-Reference with wildcards:
-Input:
+*Output*
 ```
-a.x=1
-a.*.y=2
-```
-Evaluates to:
-```
-a.x=1
-a.x.y=2
+x=1,2,3
 ```
 
-Input:
+### Substitutions:
+Example:
+
+*Input*
+```
+a.x=1
+a.y=2
+a.*.z=3
+```
+*Schema*
+```
+output=namespace
+```
+*Output*
+```
+a.x=1
+a.y=2
+a.x.z=3
+a.y.z=3
+```
+\
+Example:
+
+*Input*
 ```
 a.x=1
 a.*.y=*
+a.*.*.z=*.*
 ```
-Evaluates to:
+*Schema*
+```
+output=namespace
+```
+*Output*
 ```
 a.x=1
 a.x.y=x
+a.x.y.z=x.y
+```
+\
+Example:
+
+*Input*
+```
+a.x.y=1
+a.*.*=*.*.*.*
+```
+*Schema*
+```
+output=namespace
+```
+*Output*
+```
+a.x.y=x.y.y.y
 ```
 
-Input:
-```
-a.x=1
-b.*.=${a.*}
-```
-Evaluates to:
-```
-a.x=1
-b.x=1
-```
+### Reference with substitutions:
+Example:
 
-All use-cases above can be combined and used simultaneously, e.g.:
+*Input*
+```
+a.b.x=1
+a.b.*=${c.*}
+c.x=2
+```
+*Schema*
+```
+a.output=namespace
+```
+*Output*
+```
+b.x=2
+```
+\
+All use-cases above can be combined and used simultaneously.
 
-Input
+Example:
+
+*Input*
+```
+a.b.x=1
+a.b.*=2,${c.*},${d.*}
+c.x=3
+d.x=4
+```
+*Schema*
+```
+a.output=namespace
+```
+*Output*
+```
+b.x=2,3,4
+```
+\
+Example
+
+*Input*
 ```
 a.x.y=1
 a.*.*=1,${b.*},${c.*}
 b.x=2
-c.y=3
-```
-Evaluates to:
-```
-a.x.y=1,2,3
-```
-
-Input
-```
-a.*=1,${b.*},${c.*}
-b.x=2
 c.x=3
 ```
-Evaluates to:
+*Schema*
 ```
-a.x=1,2,3
+a.output=namespace
 ```
+*Output*
+```
+x.y=1,2,3
+```
+\
+Example:
 
-Input
+*Input*
 ```
 a.x.y=1
-a.*.*=1,*,${c.*}
-c.y=3
+a.*.*=1,*,${c.*},*
+c.x=3
 ```
-Evaluates to:
+*Schema*
 ```
-a.x.y=1,x,3
+a.output=namespace
+```
+*Output*
+```
+x.y=1,x,3,y
 ```
 
+### Ignore
+Example:
+
+*Input*
+```
+a.b=1
+!x.y=2
+```
+*Schema*
+```
+output=namespace
+```
+*Output*
+```
+a.b=1
+```
+
+It is possible to use wildcards with `!`.
+
+Example:
+
+*Input*
+```
+a.b.c=1
+a.b.d=2
+a.b.e=3
+a.x.y=4
+a.x.z=5
+!a.x.*
+```
+*Schema*
+```
+output=namespace
+```
+*Output*
+```
+a.b.c=1
+a.b.d=2
+a.b.e=3
+```
+
+### Delimiter escape
+Example:
+
+*Input*
+```
+a.b\.c=1
+```
+*Schema*
+```
+output=yaml
+```
+*Output*
+```yaml
+a:
+  b.c: 1
+```
 
 # Scheme description
 
+## Output
 
-## Supported output types
+### Supported output types
 ```
-[name.]*output=[xml|json|yaml|ini|namespace]
+[name.]*output=[xml|json|yaml|ini|namespace|quotednamespace]
+```
+
+### Full output
+Example:
+
+*Input*
+```
+a.b.x=1
+a.b.y=2
+a.c=3
+x.y=4
+```
+*Scheme*
+```
+output=namespace
+```
+*Output*
+```
+a.b.x=1
+a.b.y=2
+a.c=3
+x.y=4
+```
+
+### Partial output
+Example:
+
+*Input*
+```
+a.b.x=1
+a.b.y=2
+a.c=3
+x.y=4
+```
+*Scheme*
+```
+a.output=namespace
+```
+*Output*
+```
+b.x=1
+b.y=2
+c=3
 ```
 
 ## Set output file name or path
 ```
 [name.]*filename=<overridden file name>
 ```
+
+It is possible to write multiple output to a single file. The content will be added in case of `namespace` and `yaml` output types, otherwise it will be overriden.
 
 ## Change name of the root element(s)/namespace/INI section name
 ```
@@ -185,52 +351,204 @@ For all direct child elements treat child entry name as a key and group grand-ch
 
 Example:
 
-*scheme.txt:*
+*Input*
+```
+a.b.x=1
+a.b.y=2
+```
+*Scheme*
+```
+a.output=namespace
+a.root=c
+```
+*Output*
+```
+c.b.x=1
+c.b.y=2
+```
+
+## Keys
+Treat all elements in given namespace as a dictionary with given key attribute.
+
+Example:
+
+*Input*
+```
+a.b.x=1
+a.b.y=2
+a.c.x=3
+```
+*Scheme*
 ```
 a.output=yaml
-a.key=b
+a.key=name
 ```
-
-*input.txt:*
-```
-a.key1.x=1
-a.key1.y=2
-
-a.key2.x=5
-a.key2.y=7
-```
-
-Call:
-```
-namespace2xml -i input.txt -s scheme.txt
-```
-
-*output (a.yml):*
-```
-key1:
+*Output*
+```yaml
+- name: b
   x: 1
   y: 2
-key2:
-  x: 5
-  y: 7
+- name: c
+  x: 3
 ```
 
-
 ## Specify entry type
+```
+[name.]*type=[ignore|string|element|array|multiline]
+```
+### Ignore
+Same as using `!` before namespace in input file.
 
-`hiddenKey` - same as `key`, but the name of the key does not go to the output;
+`namespace.type=ignore` - exclude element from the output;
 
-`ignore` - exclude from the output;
+Example:
 
-`csv` - split the value by comma and produce multiple XML/JSON/YAML elements;
+*Input*
+```
+a.b.x=1
+a.b.y=2
+a.c.x=3
+```
+*Scheme*
+```
+a.output=namespace
+a.c.x.type=ignore
+```
+*Output*
+```~~~~
+b.x=1
+b.y=2
+```
 
-`string` - force element type to string for JSON and YAML;
+### String
+`namespace.type=string` - force element type to string for JSON and YAML;
 
-`element` - in case of XML output, write the entry as an element with inner text, rather than an attribute (which is default).
+Example:
 
-It's possible to specify multiple types, separated by comma, e.g. `csv,element` means split the value by comma and produce XML element with inner text fora each part.
+*Input*
+```
+a.b=1
+```
+*Scheme*
+```
+a.output=yaml
+a.b.type=string
+```
+*Output*
+```yaml
+b: '1'
+```
 
+### Element
+`namespace.type=element` - in case of XML output, write the entry as an element with inner text, rather than an attribute (which is default).
 
+### Array
+`namespace.type=array` - treat all elements in given namespace as array.
+
+Example:
+
+*Input*
+```
+a.b=1
+```
+*Scheme*
+```
+a.output=yaml
+a.b.type=string
+```
+*Output*
+```yaml
+b: '1'
+```
+
+### Multiline
+`namespace.type=multiline` - treat all elements in given namespace as multiline string for YAML.
+
+Example:
+
+*Input*
+```
+a.b.0=row1
+a.b.1=row2
+a.b.2=row3
+```
+*Scheme*
+```
+a.output=yaml
+a.b.type=multiline
+```
+*Output*
+```yaml
+b: |-
+  row1
+  row2
+  row3
+```
+
+## Specify ouptut delimiter
+Only for output types: namespace, quotednamespace
+
+Example:
+
+*Input*
+```
+a.b.c=1
+```
+*Scheme*
+```
+a.output=namespace
+a.delimiter=_
+```
+*Output*
+```
+b_c=1
+```
+
+## Disable substitutions
+`namespace.substitute=key` - disable substitutions for the value.
+
+Example:
+
+*Input*
+```
+a.b=1
+*.x=*
+```
+*Scheme*
+```
+output=namespace
+a.x.substitute=key
+```
+*Output*
+```
+a.b=1
+a.x=*
+```
+\
+`namespace.substitute=none` - disable all substitutions.
+
+Example:
+
+*Input*
+```
+a.b=1
+*.x=*
+```
+*Scheme*
+```
+output=namespace
+a.x.substitute=none
+```
+*Output*
+```
+a.b=1
+*.x=*
+```
+
+## Specify xml options
+```
+[name.]*xmloptions=[NoIndent|NewLineOnAttributes]
+```
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -449,16 +449,43 @@ Example:
 
 *Input*
 ```
-a.b=1
+a.b.b0=1
+a.b.b1=2
+a.b.b2=3
 ```
 *Scheme*
 ```
 a.output=yaml
-a.b.type=string
+a.b.type=array
 ```
 *Output*
 ```yaml
-b: '1'
+b:
+  - 1
+  - 2
+  - 3
+```
+\
+Arrays can be defined without explicit definition in the schema if indexes are used:
+
+Example:
+
+*Input*
+```
+a.b.0=1
+a.b.1=2
+a.b.2=3
+```
+*Scheme*
+```
+a.output=yaml
+```
+*Output*
+```yaml
+b:
+  - 1
+  - 2
+  - 3
 ```
 
 ### Multiline

--- a/src/Formatters/FormatterBuilder.cs
+++ b/src/Formatters/FormatterBuilder.cs
@@ -114,6 +114,7 @@ namespace Namespace2Xml.Formatters
                         keys,
                         arrays,
                         strings,
+                        multiline,
                         loggerFactory.CreateLogger<JsonFormatter>());
 
                 case OutputType.xml:
@@ -130,6 +131,7 @@ namespace Namespace2Xml.Formatters
                         qualifiedNameOptions,
                         keys,
                         arrays,
+                        multiline,
                         node.GetNamesOfType(Scheme.ValueType.element),
                         loggerFactory.CreateLogger<XmlFormatter>());
 

--- a/src/Formatters/FormatterBuilder.cs
+++ b/src/Formatters/FormatterBuilder.cs
@@ -89,6 +89,7 @@ namespace Namespace2Xml.Formatters
                                                                 select new KeyValuePair<QualifiedName, string>(child.prefix, leaf.Value));
             var arrays = node.GetNamesOfType(Scheme.ValueType.array);
             var strings = node.GetNamesOfType(Scheme.ValueType.@string);
+            var multiline = node.GetNamesOfType(Scheme.ValueType.multiline);
 
             switch (outputType)
             {
@@ -139,6 +140,7 @@ namespace Namespace2Xml.Formatters
                         keys,
                         arrays,
                         strings,
+                        multiline,
                         loggerFactory.CreateLogger<YamlFormatter>());
 
                 case OutputType.ini:

--- a/src/Formatters/JsonFormatter.cs
+++ b/src/Formatters/JsonFormatter.cs
@@ -21,12 +21,14 @@ namespace Namespace2Xml.Formatters
             IQualifiedNameMatchDictionary<string> keys,
             IQualifiedNameMatchList arrays,
             IQualifiedNameMatchList strings,
+            IQualifiedNameMatchList multiline,
             ILogger<JsonFormatter> logger)
             : base(outputStreamFactory,
                   outputPrefix,
                   keys,
                   arrays,
                   strings,
+                  multiline,
                   logger)
         { }
 
@@ -87,6 +89,12 @@ namespace Namespace2Xml.Formatters
                                     x.child,
                                     newPrefix))
                             .ToArray());
+
+                    if (multiline.IsMatch(newPrefix.ToQualifiedName()))
+                    {
+                        logger.LogWarning("Multiline value type is not supported for JSON");
+                        return null;
+                    }
 
                     return new JObject(ProcessOverrides(node.Children, newPrefix)
                         .Select(child =>

--- a/src/Formatters/JsonYamlFormatterBase.cs
+++ b/src/Formatters/JsonYamlFormatterBase.cs
@@ -13,6 +13,7 @@ namespace Namespace2Xml.Formatters
         protected readonly IQualifiedNameMatchDictionary<string> keys;
         protected readonly IQualifiedNameMatchList arrays;
         protected readonly IQualifiedNameMatchList strings;
+        protected readonly IQualifiedNameMatchList multiline;
 
         public JsonYamlFormatterBase(
             Func<Stream> outputStreamFactory,
@@ -20,12 +21,14 @@ namespace Namespace2Xml.Formatters
             IQualifiedNameMatchDictionary<string> keys,
             IQualifiedNameMatchList arrays,
             IQualifiedNameMatchList strings,
+            IQualifiedNameMatchList multiline,
             ILogger<JsonYamlFormatterBase> logger) : base(outputStreamFactory, logger)
         {
             this.outputPrefix = outputPrefix;
             this.keys = keys;
             this.arrays = arrays;
             this.strings = strings;
+            this.multiline = multiline;
         }
 
         protected static (object typedValue, bool success) TryParse(string value)

--- a/src/Formatters/XmlFormatter.cs
+++ b/src/Formatters/XmlFormatter.cs
@@ -20,6 +20,7 @@ namespace Namespace2Xml.Formatters
         private readonly XmlOptions xmlOptions;
         private readonly IQualifiedNameMatchDictionary<string> keys;
         private readonly IQualifiedNameMatchList arrays;
+        private readonly IQualifiedNameMatchList multiline;
         private readonly IQualifiedNameMatchList xmlElements;
         private readonly string rootElementName;
 
@@ -30,6 +31,7 @@ namespace Namespace2Xml.Formatters
             IOptions<QualifiedNameOptions> qualifiedNameOptions,
             IQualifiedNameMatchDictionary<string> keys,
             IQualifiedNameMatchList arrays,
+            IQualifiedNameMatchList multiline,
             IQualifiedNameMatchList xmlElements,
             ILogger<XmlFormatter> logger)
             : base(outputStreamFactory, logger)
@@ -38,6 +40,7 @@ namespace Namespace2Xml.Formatters
             this.xmlOptions = xmlOptions;
             this.keys = keys;
             this.arrays = arrays;
+            this.multiline = multiline;
             this.xmlElements = xmlElements;
             this.rootElementName = qualifiedNameOptions.Value.XmlRoot;
         }
@@ -162,6 +165,14 @@ namespace Namespace2Xml.Formatters
                         ToXml(new ProfileTreeNode(treeNode.Name, child.Children),
                             newPrefix.Concat(new[] { child.NameString }).ToArray(), true, xmlns, xmlNamespaces))
                     .ToList();
+            else if (multiline.IsMatch(newPrefix.ToQualifiedName()))
+            {
+                logger.LogWarning("Multiline value type is not supported for XML");
+                return new[]
+                {
+                    ((XObject)new XElement(XName.Get(treeNode.NameString)), (SourceMark)null)
+                };
+            }
             else
             {
                 nodes = treeNode.Children

--- a/src/Formatters/YamlFormatter.cs
+++ b/src/Formatters/YamlFormatter.cs
@@ -17,8 +17,6 @@ namespace Namespace2Xml.Formatters
 {
     public class YamlFormatter : JsonYamlFormatterBase
     {
-        protected readonly IQualifiedNameMatchList multiline;
-
         public YamlFormatter(
             Func<Stream> outputStreamFactory,
             [NullGuard.AllowNull] IReadOnlyList<string> outputPrefix,
@@ -32,9 +30,9 @@ namespace Namespace2Xml.Formatters
                 keys,
                 arrays,
                 strings,
+                multiline,
                 logger)
         {
-            this.multiline = multiline;
         }
 
         protected override async Task DoWrite(ProfileTree tree, Stream stream, CancellationToken cancellationToken)

--- a/src/Scheme/SchemeNodeExtensions.cs
+++ b/src/Scheme/SchemeNodeExtensions.cs
@@ -2,16 +2,22 @@
 using Namespace2Xml.Syntax;
 using System.Collections.Generic;
 using System.Linq;
+using Namespace2Xml.Formatters;
 
 namespace Namespace2Xml.Scheme
 {
     public static class SchemeNodeExtensions
     {
-        public static IEnumerable<IProfileEntry> WithImplicitArrays(this SchemeNode node, ProfileTree tree)
+        public static IEnumerable<IProfileEntry> WithImplicitArrays(this SchemeNode schemeNode, ProfileTree profileTree)
         {
-            var originalPayload = node.GetOriginalPayload().ToList();
-            var implicitArrays = (from pair in tree.GetAllChildren()
-                                  where IsArray(pair.tree)
+            var arrays = schemeNode.GetNamesOfType(Scheme.ValueType.array);
+            var multiline = schemeNode.GetNamesOfType(Scheme.ValueType.multiline);
+
+            var originalPayload = schemeNode.GetOriginalPayload().ToList();
+            var implicitArrays = (from pair in profileTree.GetAllChildren()
+                                  where !arrays.IsMatch(pair.prefix)
+                                        && !multiline.IsMatch(pair.prefix)
+                                        && IsArray(pair.tree)
                                   select new Payload(
                                       new QualifiedName(pair.prefix.Parts.Append(new NamePart(new[] { new TextNameToken("type") }))),
                                       new[] { new TextValueToken("array") }, pair.tree.GetFirstSourceMark())).ToList();
@@ -24,10 +30,15 @@ namespace Namespace2Xml.Scheme
             if (!(tree is ProfileTreeNode node))
                 return false;
 
-            var cnt = node.Children.Count(child => child.Name.Tokens.Count == 1 && child.Name.Tokens[0] is TextNameToken token && token.Text.All(char.IsDigit));
+            var cnt = node.Children.Count(
+                child =>
+                    child.Name.Tokens.Count == 1
+                    && child.Name.Tokens[0] is TextNameToken token
+                    && token.Text.All(char.IsDigit));
 
-            return cnt > 0 && cnt == node.Children
-                .Count(child => !(child.Name.Tokens.Count == 1 && child.Name.Tokens[0] is SubstituteNameToken));
+            return cnt > 0
+                   && cnt == node.Children
+                       .Count(child => !(child.Name.Tokens.Count == 1 && child.Name.Tokens[0] is SubstituteNameToken));
         }
     }
 }

--- a/src/Scheme/ValueType.cs
+++ b/src/Scheme/ValueType.cs
@@ -6,6 +6,7 @@
         ignore,
         array,
         @string,
-        element
+        element,
+        multiline
     }
 }

--- a/src/Semantics/TreeBuilder.cs
+++ b/src/Semantics/TreeBuilder.cs
@@ -274,11 +274,11 @@ namespace Namespace2Xml.Semantics
         {
             var entriesList = new ProfileEntryList(entries);
 
-            while (ApplySubstitutesStep(entriesList)) ;
+            while (ApplySubstitutesStep(entriesList)) { }
 
             return entriesList.Where(entry => entry is not Payload p ||
-                p.GetNameSubstitutesCount() == 0 &&
-                p.GetValueRefSubstitutesCount() == 0);
+                                              p.GetNameSubstitutesCount() == 0 &&
+                                              p.GetValueRefSubstitutesCount() == 0);
         }
 
         private bool ApplySubstitutesStep(ProfileEntryList entries)
@@ -431,8 +431,6 @@ namespace Namespace2Xml.Semantics
 
             foreach (var pattern in patterns)
             {
-                var hasPatternSubstitutes = false;
-
                 var matchesByName = entriesToProcess.GetLeftMatches(pattern);
 
                 var substituteResults = matchesByName
@@ -456,18 +454,9 @@ namespace Namespace2Xml.Semantics
                             pattern.SourceMark.FileName,
                             pattern.SourceMark.LineNumber,
                             result.MatchInfo);
-                        hasPatternSubstitutes = true;
+                        hasSubstitutes = true;
                     }
                 }
-
-                if (hasPatternSubstitutes)
-                {
-                    // Remove pattern from entries
-
-                    entries.Remove(pattern);
-                }
-
-                hasSubstitutes |= hasPatternSubstitutes;
             }
 
             return hasSubstitutes;
@@ -477,7 +466,7 @@ namespace Namespace2Xml.Semantics
         {
             var entriesList = new ProfileEntryList(entries);
 
-            while (ApplyNameSubstitutes(entriesList)) ;
+            while (ApplyNameSubstitutes(entriesList)) { }
 
             return entriesList.Where(entry =>
                 entry is not Payload p
@@ -513,12 +502,6 @@ namespace Namespace2Xml.Semantics
                 {
                     if (entries.InsertAfterIfNotExists(pattern, result.MatchedPayload))
                     {
-                        // logger.LogDebug(
-                        //     "Substitute one-to-one by name: {name}, file: {file}, line: {line}, matches: {matches}",
-                        //     pattern.Name,
-                        //     pattern.SourceMark.FileName,
-                        //     pattern.SourceMark.LineNumber,
-                        //     result.MatchInfo);
                         hasSubstitutes = true;
                     }
                 }

--- a/tests/JsonFormatterTests.cs
+++ b/tests/JsonFormatterTests.cs
@@ -32,6 +32,7 @@ namespace Namespace2Xml.Tests
                 new QualifiedNameMatchDictionary<string>(),
                 new QualifiedNameMatchList(arrays.Select(a => a.Split('.').ToQualifiedName())),
                 strings,
+                new QualifiedNameMatchList(),
                 Mock.Of<ILogger<JsonFormatter>>());
 
         [Test]

--- a/tests/XmlFormatterTests.cs
+++ b/tests/XmlFormatterTests.cs
@@ -46,6 +46,7 @@ namespace Namespace2Xml.Tests
                 new QualifiedNameMatchList(arrays
                     .Select(x => x.Split('.').ToQualifiedName())),
                 new QualifiedNameMatchList(),
+                new QualifiedNameMatchList(),
                 Mock.Of<ILogger<XmlFormatter>>());
 
         [Test]

--- a/tests/YamlFormatterTests.cs
+++ b/tests/YamlFormatterTests.cs
@@ -14,12 +14,14 @@ namespace Namespace2Xml.Tests
     public class YamlFormatterTests
     {
         private List<QualifiedName> strings;
+        private List<QualifiedName> multiline;
         private MemoryStream stream;
 
         [SetUp]
         public void Setup()
         {
             strings = new List<QualifiedName>();
+            multiline = new List<QualifiedName>();
             stream = new MemoryStream();
         }
 
@@ -30,6 +32,7 @@ namespace Namespace2Xml.Tests
                 new QualifiedNameMatchDictionary<string>(),
                 new QualifiedNameMatchList(),
                 new QualifiedNameMatchList(strings),
+                new QualifiedNameMatchList(multiline),
                 Mock.Of<ILogger<YamlFormatter>>());
 
         [Test]
@@ -65,12 +68,30 @@ namespace Namespace2Xml.Tests
             CheckYaml("x:" + expectedValue);
         }
 
+        [Test]
+        [TestCase("row1\nrow2", "|-\r\n  row1\r\n  row2")]
+        [TestCase("row1\n row2", "|-\r\n  row1\r\n   row2")]
+        public async Task ShouldFormatMultiline(string value, string expectedValue)
+        {
+            multiline.Add(new[] { "a", "x" }.ToQualifiedName());
+
+            await CreateFormatter().Write(
+                Helpers.ToTree(new { a = new { x = value } }),
+                default);
+
+            CheckYamlRaw("x: " + expectedValue + "\r\n");
+        }
+
         private void CheckYaml(string expectedXml) =>
             Encoding.UTF8.GetString(stream.ToArray())
             .Replace("\r", "")
             .Replace("\n", "")
             .Replace(" ", "")
             .ShouldBe(expectedXml);
+
+        private void CheckYamlRaw(string expectedXml) =>
+            Encoding.UTF8.GetString(stream.ToArray())
+                .ShouldBe(expectedXml);
 
         [TearDown]
         public void TearDown()


### PR DESCRIPTION
- Updated readme
- Added multiline value type:

profile:
```
a.b.0=row0
a.b.1=row1
a.b.2=row2
```
schema:
```
a.output=yaml
a.b.type=multiline
```
ouptut:
```
b: |-
  row0
  row1
  row2
```

- Fixed bug with substitutions:
Profile:
```
a.rules.0.paths.0.path=path0
a.rules.*.paths.10.path=path10
a.rules.0.paths.*.servicename=444
```
Expected output:
```
rules:
- paths:
  - path: path0
    servicename: 444
  - path: path10
    servicename: 444
```
Actual output:
```
rules:
- paths:
  - path: path0
    servicename: 444
  - path: path10
```